### PR TITLE
Replace Jason with a custom encoder

### DIFF
--- a/lib/opentelemetry_alcotest/common/json_encoder.ex
+++ b/lib/opentelemetry_alcotest/common/json_encoder.ex
@@ -1,0 +1,42 @@
+defmodule OpentelemetryAlcotest.Common.JsonEncoder do
+  require Logger
+
+  def encode(nil), do: "{}"
+
+  def encode(enum) when is_map(enum) do
+    Enum.flat_map(enum, fn {k, v} ->
+      ["\"#{k}\":", encode(v)]
+    end)
+    |> List.insert_at(0, "{")
+    |> List.insert_at(-1, "}")
+    |> Enum.join()
+  end
+
+  def encode(value) when is_binary(value) do
+    "\"#{value}\""
+  end
+
+  def encode(value) when is_bitstring(value) do
+    "\"[REDACTED]\""
+  end
+
+  def encode(enum) when is_list(enum) do
+    Enum.map(enum, &encode/1)
+    |> Enum.join(",")
+    |> then(fn str -> "[#{str}]" end)
+  end
+
+  def encode(value) when is_atom(value) do
+    Atom.to_string(value)
+  end
+
+  def encode(value) when is_number(value) do
+    to_string(value)
+  end
+
+  def encode(value) do
+    Logger.warning("Alcotest.JsonEncoder.encode/1: unsupported type #{inspect(value)}")
+
+    "\"[REDACTED]\""
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,6 @@ defmodule OpentelemetryAlcotest.MixProject do
   defp deps do
     [
       {:absinthe, "~> 1.7.0"},
-      {:jason, "~> 1.2"},
       {:opentelemetry_api, "~> 1.1"},
       {:telemetry, "~> 0.4 or ~> 1.0"}
     ]

--- a/test/common/json_encoder_test.exs
+++ b/test/common/json_encoder_test.exs
@@ -1,0 +1,63 @@
+defmodule Common.JsonEncoderTest do
+  use ExUnit.Case
+
+  alias OpentelemetryAlcotest.Common.JsonEncoder, as: Encoder
+
+  describe "encode/1" do
+    test "with nil" do
+      input = nil
+      expected = "{}"
+      assert Encoder.encode(input) == expected
+    end
+
+    test "with an empty map" do
+      input = %{}
+      expected = "{}"
+      assert Encoder.encode(input) == expected
+    end
+
+    test "with a nested integer" do
+      input = %{
+        "input" => %{
+          "userId" => 1
+        }
+      }
+
+      expected = "{\"input\":{\"userId\":1}}"
+      assert Encoder.encode(input) == expected
+    end
+
+    test "with a nested list of integers" do
+      input = %{
+        "input" => %{
+          "userIds" => [1, 2, 3]
+        }
+      }
+
+      expected = "{\"input\":{\"userIds\":[1,2,3]}}"
+      assert Encoder.encode(input) == expected
+    end
+
+    test "with a nested string" do
+      input = %{
+        "input" => %{
+          "userIds" => "Hello world"
+        }
+      }
+
+      expected = "{\"input\":{\"userIds\":\"Hello world\"}}"
+      assert Encoder.encode(input) == expected
+    end
+
+    test "with a nested bitstring" do
+      input = %{
+        "input" => %{
+          "token" => <<3::4>>
+        }
+      }
+
+      expected = "{\"input\":{\"token\":\"[REDACTED]\"}}"
+      assert Encoder.encode(input) == expected
+    end
+  end
+end


### PR DESCRIPTION
I initially worked on this to workaround an issue with Jason and invalid bytes, but then realized the string that was causing the issue may not be properly handled at all.

It might still be interesting to avoid depending on a library just to use one function, though.